### PR TITLE
Add colorloop support

### DIFF
--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -65,7 +65,7 @@ class PixelHandler : public LightHandler {
             // progress will start at 0.0 and end at 1.0
             float currentHue = newColor.H + param.progress;
             if (currentHue > 1) currentHue -= 1;
-            HslColor updatedColor = HslColor(currentHue, 1, 0.5);
+            HslColor updatedColor = HslColor(currentHue, newColor.S, newColor.L);
             RgbColor currentColor = updatedColor;
             strip.SetPixelColor(lightNumber, updatedColor);
 

--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -63,7 +63,9 @@ class PixelHandler : public LightHandler {
             colorloopIndex = param.index;
 
             // progress will start at 0.0 and end at 1.0
-            HslColor updatedColor = HslColor(param.progress, 1, 0.5);
+            float currentHue = newColor.H + param.progress;
+            if (currentHue > 1) currentHue -= 1;
+            HslColor updatedColor = HslColor(currentHue, 1, 0.5);
             RgbColor currentColor = updatedColor;
             strip.SetPixelColor(lightNumber, updatedColor);
 


### PR DESCRIPTION
This adds per-pixel colorloop support with a continuous 60s hue fade. Note that the hue fade starts with the specified (or previous if not re-specified) color values, so keeping saturation and brightness at 255 will make the colorfade look entirely white.