### PR TITLE
Fix interop with original Hue offical android app

### DIFF
--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -67,7 +67,7 @@ void LightServiceClass::begin() {
 
   HTTP.begin();
 
-  Serial.printf("Starting SSDP...\n");
+  Serial.println("Starting SSDP...");
   SSDP.begin();
   SSDP.setSchemaURL((char*)"description.xml");
   SSDP.setHTTPPort(80);
@@ -266,9 +266,9 @@ void addLightJson(aJsonObject* root, int numberOfTheLight, LightHandler *lightHa
 void addConfigJson(aJsonObject *root)
 {
   aJson.addStringToObject(root, "name", "hue emulator");
-  aJson.addStringToObject(root, "swversion", "0.1");
-  // aJson.addBooleanToObject(root, "portalservices", false);
-  // aJson.addStringToObject(root, "zigbeechannel", "0"); // As per spec, 0 is allowed
+  aJson.addStringToObject(root, "swversion", "001");
+  aJson.addBooleanToObject(root, "portalservices", false);
+  aJson.addBooleanToObject(root, "linkbutton", false);
   aJson.addStringToObject(root, "mac", macString.c_str());
   aJson.addBooleanToObject(root, "dhcp", true);
   aJson.addStringToObject(root, "ipaddress", ipString.c_str());


### PR DESCRIPTION
According to the crashes I fixed in the original/old Hue Android app, swversion must be of type long (floats break it) and portalservices and linkbutton are required boolean values.

The new Hue Android app is another mess altogether. It can't autodiscover the emulated bridge for some reason and crashes in native code (no reasonable backtrace) when provided with an IP to use. If you have any insight there I'd be happy to hear it.

Neither of these apps worked when I originally started tinkering with this code, so they may have updated them at some point and changed the requirements for what it takes to discover and appear to be a bridge since this was originally written.