### PR TITLE
Improve compatibility and add group support

### DIFF
--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -22,9 +22,21 @@ LightServiceClass LightService;
 LightHandler *lightHandlers[MAX_LIGHT_HANDLERS]; // interfaces exposed to the outside world
 
 bool LightServiceClass::setLightHandler(int index, LightHandler *handler) {
-  if (index >= MAX_LIGHT_HANDLERS || index < 0) return false;
+  if (index >= currentNumLights || index < 0) return false;
   lightHandlers[index] = handler;
   return true;
+}
+
+bool LightServiceClass::setLightsAvailable(int lights) {
+  if (lights <= MAX_LIGHT_HANDLERS) {
+    currentNumLights = lights;
+    return true;
+  }
+  return false;
+}
+
+int LightServiceClass::getLightsAvailable() {
+  return currentNumLights;
 }
 
 String StringIPaddress(IPAddress myaddr)
@@ -39,7 +51,7 @@ String StringIPaddress(IPAddress myaddr)
 }
 
 LightHandler *LightServiceClass::getLightHandler(int numberOfTheLight) {
-  if (numberOfTheLight >= MAX_LIGHT_HANDLERS || numberOfTheLight < 0) {
+  if (numberOfTheLight >= currentNumLights || numberOfTheLight < 0) {
     return nullptr;
   }
 
@@ -264,7 +276,7 @@ void addLightJson(aJsonObject* root, int numberOfTheLight, LightHandler *lightHa
 }
 
 void addLightsJson(aJsonObject *lights) {
-  for (int i = 0; i < MAX_LIGHT_HANDLERS; i++) {
+  for (int i = 0; i < LightService.getLightsAvailable(); i++) {
     addLightJson(lights, i, LightService.getLightHandler(i));
   }
 }
@@ -423,7 +435,7 @@ void groupsHandler(String user, String uri) {
   Serial.println(HTTP.arg("plain"));
   aJsonObject* parsedRoot = aJson.parse(( char*) HTTP.arg("plain").c_str());
   if (parsedRoot) {
-    for (int i = 0; i < MAX_LIGHT_HANDLERS; i++) {
+    for (int i = 0; i < LightService.getLightsAvailable(); i++) {
       LightHandler *handler = LightService.getLightHandler(i);
       HueLightInfo currentInfo = handler->getInfo(i);
       HueLightInfo newInfo;

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -184,6 +184,20 @@ void sendError(int type, String path, String description) {
   sendJson(root);
 }
 
+void sendSuccess(String id, String value) {
+  aJsonObject *search = aJson.createArray();
+  aJsonObject *container = aJson.createObject();
+  aJson.addItemToArray(search, container);
+  aJsonObject *succeed = aJson.createObject();
+  aJson.addItemToObject(container, "success", succeed);
+  aJson.addStringToObject(succeed, id.c_str(), value.c_str());
+  sendJson(search);
+}
+
+void sendUpdated() {
+  HTTP.send(200, "text/plain", "Updated.");
+}
+
 bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLightInfo *newInfo) {
   *newInfo = currentInfo;
   aJsonObject* onState = aJson.getObjectItem(parsedRoot, "on");
@@ -328,9 +342,7 @@ void authHandler(String user, String uri) {
   Serial.println("CLIENT: ");
   Serial.println(username);
 
-  String str = "[{\"success\":{\"username\": \"" + username + "\"}}]";
-  HTTP.send(200, "text/plain", str);
-  Serial.println(str);
+  sendSuccess("username", username);
 }
 
 void lightsHandler(String user, String uri) {
@@ -346,13 +358,7 @@ void lightsHandler(String user, String uri) {
         }
       case HTTP_POST: {
           // "start" a "search" for "new" lights
-          aJsonObject *search = aJson.createArray();
-          aJsonObject *container = aJson.createObject();
-          aJson.addItemToArray(search, container);
-          aJsonObject *succeed = aJson.createObject();
-          aJson.addItemToObject(container, "success", succeed);
-          aJson.addStringToObject(succeed, "/lights", "Searching for new devices");
-          sendJson(search);
+          sendSuccess("/lights", "Searching for new devices");
           break;
         }
     }
@@ -446,7 +452,7 @@ void groupsHandler(String user, String uri) {
     aJson.deleteItem(parsedRoot);
 
     // As per the spec, the response can be "Updated." for memory-constrained devices
-    HTTP.send(200, "text/plain", "Updated.");
+    sendUpdated();
   } else if (HTTP.arg("plain") != "") {
     // unparseable json
     sendError(2, "groups/0/action", "Bad JSON body in request");

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -143,7 +143,7 @@ int getSaturation(HsbColor hsb) {
 }
 
 RgbColor getMirektoRGB(int mirek) {
-  int hectemp = 10000/mirek;
+  int hectemp = 10000 / mirek;
   int r, g, b;
   if (hectemp <= 66) {
     r = COLOR_SATURATION;
@@ -266,7 +266,7 @@ void addLightJson(aJsonObject* root, int numberOfTheLight, LightHandler *lightHa
 void addConfigJson(aJsonObject *root)
 {
   aJson.addStringToObject(root, "name", "hue emulator");
-  aJson.addStringToObject(root, "swversion", "001");
+  aJson.addStringToObject(root, "swversion", "81012917");
   aJson.addBooleanToObject(root, "portalservices", false);
   aJson.addBooleanToObject(root, "linkbutton", false);
   aJson.addStringToObject(root, "mac", macString.c_str());
@@ -274,6 +274,7 @@ void addConfigJson(aJsonObject *root)
   aJson.addStringToObject(root, "ipaddress", ipString.c_str());
   aJson.addStringToObject(root, "netmask", netmaskString.c_str());
   aJson.addStringToObject(root, "gateway", gatewayString.c_str());
+  aJson.addStringToObject(root, "apiversion", "1.3.0");
   aJsonObject *whitelist;
   aJson.addItemToObject(root, "whitelist", whitelist = aJson.createObject());
   aJsonObject *whitelistFirstEntry;

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -454,6 +454,11 @@ void groupsHandler(String user, String uri) {
 }
 
 void scenesHandler(String user, String uri) {
+  uri = trimSlash(uri.substring(6));
+  if (uri == "" && HTTP.method() == HTTP_GET) {
+    HTTP.send(200, "text/plain", "{}");
+    return;
+  }
   // no part of /api/user/scenes is supported, so all methods are unsupported
   sendError(4, "/api/" + user + "/" + uri, "Method not supported for scenes");
 }

--- a/ESP8266HueEmulator/LightService.h
+++ b/ESP8266HueEmulator/LightService.h
@@ -36,9 +36,13 @@ class LightHandler {
 class LightServiceClass {
     public:
       LightHandler *getLightHandler(int numberOfTheLight);
+      bool setLightsAvailable(int numLights);
+      int getLightsAvailable();
       bool setLightHandler(int index, LightHandler *handler);
       void begin();
       void update();
+    private:
+      int currentNumLights = MAX_LIGHT_HANDLERS;
 };
 
 extern LightServiceClass LightService;


### PR DESCRIPTION
This fixes some client crashes with the new Hue app (still non-functional and still non-discoverable, but I'm on the way there), makes the number of exposed lights configurable via a call to the class, returns an empty object for scenes queries (this speeds up client querying versus blank responses), and adds group support (except for scene usage, I'm getting there).

On a side note, I do have local experimental code working for discovery with the new Hue app, but it requires tweaks to the SSDP library since the new Hue app requires the message elements in a certain order and requires non-standard elements in the response (hue-bridgeid). I'm working up a more generic patch that will be more likely to go in to the official ESP8266 hardware package, but that will take some time and probably won't be available in the board manager for even longer.