### PR TITLE
Provide raw JSON and fix timing

### DIFF
--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -42,7 +42,7 @@ class PixelHandler : public LightHandler {
     HueLightInfo _info;
     int16_t colorloopIndex = -1;
   public:
-    void handleQuery(int lightNumber, HueLightInfo newInfo) {
+    void handleQuery(int lightNumber, HueLightInfo newInfo, aJsonObject* raw) {
       // define the effect to apply, in this case linear blend
       HslColor newColor = HslColor(getHsb(newInfo.hue, newInfo.saturation, newInfo.brightness));
       HslColor originalColor = strip.GetPixelColor(lightNumber);

--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -108,12 +108,12 @@ void setup() {
 
   // Show that the NeoPixels are alive
   delay(120); // Apparently needed to make the first few pixels animate correctly
-  infoLight(white);
-
   Serial.begin(115200);
 
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
+  infoLight(white);
+
   if (WiFi.waitForConnectResult() != WL_CONNECTED) {
     Serial.println("WiFi Failed");
     // Show that we are connected

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -446,8 +446,8 @@ void lightsHandler(String user, String uri) {
         aJson.deleteItem(parsedRoot);
         return;
       }
+      handler->handleQuery(numberOfTheLight, newInfo, parsedRoot);
       aJson.deleteItem(parsedRoot);
-      handler->handleQuery(numberOfTheLight, newInfo);
     } else if (HTTP.arg("plain") != "") {
       // unparseable json
       sendError(2, "groups/0/action", "Bad JSON body in request");
@@ -481,7 +481,7 @@ void applyConfigToLightMask(unsigned int lights) {
       HueLightInfo currentInfo = handler->getInfo(i);
       HueLightInfo newInfo;
       if (parseHueLightInfo(currentInfo, parsedRoot, &newInfo)) {
-        handler->handleQuery(i, newInfo);
+        handler->handleQuery(i, newInfo, parsedRoot);
       }
     }
     aJson.deleteItem(parsedRoot);

--- a/ESP8266HueEmulator/LightService.h
+++ b/ESP8266HueEmulator/LightService.h
@@ -19,10 +19,13 @@ struct HueLightInfo {
   HueEffect effect = EFFECT_NONE;
 };
 
+class aJsonObject;
+bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLightInfo *newInfo);
+
 class LightHandler {
   public:
     // These functions include light number as a single LightHandler could conceivably service several lights
-    virtual void handleQuery(int lightNumber, HueLightInfo info) {}
+    virtual void handleQuery(int lightNumber, HueLightInfo info, aJsonObject* raw) {}
     virtual HueLightInfo getInfo(int lightNumber) {
       HueLightInfo info;
       return info;


### PR DESCRIPTION
This adds a JSON argument so that handers can implement additional functionality and resolves a timing issue where the initialization animation was causing WiFi failures.