### PR TITLE
Handle no-id scene creation properly

### DIFF
--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -775,6 +775,9 @@ void sceneCreationHandler(String id) {
   }
   // updateSceneSlot sends failure messages
   if (!updateSceneSlot(sceneIndex, id, HTTP.arg("plain"))) {
+    if (id == "") {
+      id = String(sceneIndex);
+    }
     lightScenes[sceneIndex]->id = id;
     sendSuccess("id", id);
     return;


### PR DESCRIPTION
This fixes issues to POST /api/<user>/scenes that create a new scene without specifying an ID.