### PR TITLE
Respond properly to groups DELETE

### DIFF
--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -696,9 +696,14 @@ void groupsHandler(String user, String uri) {
         updateGroupSlot(groupNum, HTTP.arg("plain"));
         sendUpdated();
         break;
-      case HTTP_DELETE:
+      case HTTP_DELETE: {
         updateGroupSlot(groupNum, "");
+        String message = "/groups/";
+        message += (groupNum + 1);
+        message += " deleted";
+        sendSuccess(message);
         break;
+      }
       default:
         sendError(4, "/api/" + user + "/groups", "Group method not supported");
         break;


### PR DESCRIPTION
This was never implemented correctly in the first place. Groups DELETE will now respond with the proper message.