### PR TITLE
Allow POST on light state setting for ease of use

### DIFF
--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -628,6 +628,7 @@ void lightsIdStateFn(WcFnRequestHandler *whandler, String requestUri, HTTPMethod
   }
 
   switch (method) {
+    case HTTP_POST:
     case HTTP_PUT: {
       Serial.print("JSON Body:");
       Serial.println(HTTP->arg("plain"));


### PR DESCRIPTION
In most cases, it's a bit less work to send a POST instead of a PUT and doesn't hurt the API, so allow it for testing purposes. This was allowed before the HTTP server callback rework and was lost in that process since it wasn't to API spec.