### PR TITLE
fixes #59, #36 + sleep as android working + transitionTime implemented

### DIFF
--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -117,11 +117,10 @@ void setup() {
   WiFi.begin(ssid, password);
   infoLight(white);
 
-  if (WiFi.waitForConnectResult() != WL_CONNECTED) {
-    Serial.println("WiFi Failed");
-    // Show that we are connected
+  while (WiFi.status() != WL_CONNECTED) {
     infoLight(red);
-    while (1) delay(100);
+    delay(500);
+    Serial.print(".");
   }
   
   // Port defaults to 8266

--- a/ESP8266HueEmulator/ESP8266HueEmulator.ino
+++ b/ESP8266HueEmulator/ESP8266HueEmulator.ino
@@ -24,7 +24,6 @@ RgbColor red = RgbColor(COLOR_SATURATION, 0, 0);
 RgbColor green = RgbColor(0, COLOR_SATURATION, 0);
 RgbColor white = RgbColor(COLOR_SATURATION);
 RgbColor black = RgbColor(0);
-unsigned int transitionTime = 800; // by default there is a transition time to the new state of 400 milliseconds
 
 // Settings for the NeoPixels
 #define pixelCount 30
@@ -86,7 +85,7 @@ class PixelHandler : public LightHandler {
           HslColor updatedColor = HslColor::LinearBlend<NeoHueBlendShortestDistance>(originalColor, newColor, param.progress);
           strip.SetPixelColor(lightNumber, updatedColor);
         };
-        animator.StartAnimation(lightNumber, transitionTime, animUpdate);
+        animator.StartAnimation(lightNumber, _info.transitionTime, animUpdate);
       }
       else
       {
@@ -96,7 +95,7 @@ class PixelHandler : public LightHandler {
           HslColor updatedColor = HslColor::LinearBlend<NeoHueBlendShortestDistance>(originalColor, black, param.progress);
           strip.SetPixelColor(lightNumber, updatedColor);
         };
-        animator.StartAnimation(lightNumber, transitionTime, animUpdate);
+        animator.StartAnimation(lightNumber, _info.transitionTime, animUpdate);
       }
     }
 

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -904,6 +904,7 @@ bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLig
       newInfo->effect = EFFECT_NONE;
     }
   }
+  
   // pull alert
   aJsonObject* alertState = aJson.getObjectItem(parsedRoot, "alert");
   if (alertState) {
@@ -915,6 +916,12 @@ bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLig
     } else {
       newInfo->alert = ALERT_NONE;
     }
+  }
+
+  // pull transitiontime
+  aJsonObject* transitiontimeState = aJson.getObjectItem(parsedRoot, "transitiontime");
+  if (transitiontimeState) {
+    newInfo->transitionTime = transitiontimeState->valueint;
   }
 
   aJsonObject* hueState = aJson.getObjectItem(parsedRoot, "hue");

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -268,7 +268,7 @@ int ssdpMsgFormatCallback(SSDPClass *ssdp, char *buffer, int buff_len,
       interval,
       ipString.c_str(), port, schemaURL,
       modelName, modelNumber,
-      "001788FFFE142F92",
+      bridgeIDString.c_str(),
       deviceType,
       uuid);
   }

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -230,7 +230,7 @@ static const char* _ssdp_response_template =
   "HTTP/1.1 200 OK\r\n"
   "EXT:\r\n"
   "CACHE-CONTROL: max-age=%u\r\n" // SSDP_INTERVAL
-  "LOCATION: http://%u.%u.%u.%u:%u/%s\r\n" // WiFi.localIP(), _port, _schemaURL
+  "LOCATION: http://%s:%u/%s\r\n" // WiFi.localIP(), _port, _schemaURL
   "SERVER: Arduino/1.0 UPNP/1.1 %s/%s\r\n" // _modelName, _modelNumber
   "hue-bridgeid: %s\r\n"
   "ST: %s\r\n"  // _deviceType

--- a/ESP8266HueEmulator/LightService.cpp
+++ b/ESP8266HueEmulator/LightService.cpp
@@ -713,6 +713,7 @@ void lightsNewFn(WcFnRequestHandler *handler, String requestUri, HTTPMethod meth
 void LightServiceClass::begin() {
   begin(new ESP8266WebServer(80));
 }
+
 void LightServiceClass::begin(ESP8266WebServer *svr) {
   HTTP = svr;
   macString = String(WiFi.macAddress());
@@ -732,6 +733,7 @@ void LightServiceClass::begin(ESP8266WebServer *svr) {
   on(configFn, "/api/*/config", HTTP_ANY);
   on(configFn, "/api/config", HTTP_GET);
   on(wholeConfigFn, "/api/*", HTTP_GET);
+  on(wholeConfigFn, "/api/", HTTP_GET);
   on(authFn, "/api", HTTP_POST);
   on(unimpFn, "/api/*/schedules", HTTP_GET);
   on(unimpFn, "/api/*/rules", HTTP_GET);

--- a/ESP8266HueEmulator/LightService.h
+++ b/ESP8266HueEmulator/LightService.h
@@ -17,6 +17,7 @@ struct HueLightInfo {
   int hue = 0, saturation = 0;
   HueAlert alert = ALERT_NONE;
   HueEffect effect = EFFECT_NONE;
+  unsigned int transitionTime = 800; // by default there is a transition time to the new state of 400 milliseconds
 };
 
 class aJsonObject;


### PR DESCRIPTION
Here are some fixes for issue  #59 and #36. I implemented the transitionTime, which is not really useful, but what else on a Friday night. It seems I got Sleep as Android smart light support working, so I can use this as a wake-up light.