### PR TITLE
Use adafruit/travis-ci-arduino eeaeaf8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: false
 notifications: false
 before_install:
-  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/eeaeaf8fa253465d18785c2bb589e14ea9893f9f/install.sh)
 install:
   - mkdir -p $HOME/arduino_ide/libraries/
   - cd $HOME/arduino_ide/libraries/


### PR DESCRIPTION
This version uses `arduino-1.6.5-linux64.tar.xz`, and ESP8266HueEmulator may compile with this version but not with newer ones until someone updates ESP8266HueEmulator and/or the libraries it uses to handle newer versions of Arduino.